### PR TITLE
Adiciona opção de passar um encoding no construtor do objeto

### DIFF
--- a/nuget/Vip.Printer.nuspec
+++ b/nuget/Vip.Printer.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Vip.Printer</id>
-    <version>1.0.18</version>
+    <version>1.0.19</version>
     <authors>Leandro Ferreira</authors>
     <owners>VIP Soluções</owners>
     <projectUrl>https://github.com/leandrovip/Vip.Printer</projectUrl>

--- a/src/Vip.Printer/Helper/RawPrinterHelper.cs
+++ b/src/Vip.Printer/Helper/RawPrinterHelper.cs
@@ -129,34 +129,6 @@ namespace Vip.Printer.Helper
             return retval;
         }
 
-        public static bool SendStringToPrinter(string szPrinterName, string szString)
-        {
-            // How many characters are in the string?
-            var dwCount = szString.Length;
-
-            // Assume that the printer is expecting ANSI text, and then convert
-            // the string to ANSI text.
-            var pBytes = Marshal.StringToCoTaskMemAnsi(szString);
-
-            // Send the converted ANSI string to the printer.
-            var result = SendBytesToPrinter(szPrinterName, pBytes, dwCount);
-            Marshal.FreeCoTaskMem(pBytes);
-
-            return result;
-        }
-
-        //if you want a wrapper function for you strings :
-        public static bool SendAsciiToPrinter(string szPrinterName, string data)
-        {
-            var retval = false;
-
-            //if  you are using UTF-8 and get wrong values in qrcode printing, you must use ASCII instead.
-            //retval = SendBytesToPrinter(szPrinterName, Encoding.UTF8.GetBytes(data));
-            retval = SendBytesToPrinter(szPrinterName, Encoding.ASCII.GetBytes(data));
-
-            return retval;
-        }
-
         #endregion
     }
 }

--- a/src/Vip.Printer/Printer.cs
+++ b/src/Vip.Printer/Printer.cs
@@ -50,6 +50,7 @@ namespace Vip.Printer
         private readonly string _printerName;
         private readonly IPrintCommand _command;
         private readonly PrinterType _printerType;
+        private readonly Encoding _encoding;
 
         #endregion
 
@@ -63,10 +64,12 @@ namespace Vip.Printer
         /// <param name="colsNormal">Number of columns for normal mode print</param>
         /// <param name="colsCondensed">Number of columns for condensed mode print</param>
         /// <param name="colsExpanded">Number of columns for expanded mode print</param>
-        public Printer(string printerName, PrinterType type, int colsNormal, int colsCondensed, int colsExpanded)
+        /// <param name="encoding">Custom encoding</param>
+        public Printer(string printerName, PrinterType type, int colsNormal, int colsCondensed, int colsExpanded, Encoding encoding)
         {
             _printerName = string.IsNullOrEmpty(printerName) ? "temp.prn" : printerName.Trim();
             _printerType = type;
+            _encoding = encoding;
 
             #region Select printer type
 
@@ -98,8 +101,26 @@ namespace Vip.Printer
         ///     Initializes a new instance of the <see cref="Printer" /> class.
         /// </summary>
         /// <param name="printerName">Printer name, shared name or port of printer install</param>
+        /// <param name="type">Command set of type printer</param>
+        /// <param name="colsNormal">Number of columns for normal mode print</param>
+        /// <param name="colsCondensed">Number of columns for condensed mode print</param>
+        /// <param name="colsExpanded">Number of columns for expanded mode print</param>
+        public Printer(string printerName, PrinterType type, int colsNormal, int colsCondensed, int colsExpanded) : this(printerName, type, colsNormal, colsCondensed, colsExpanded, null) { }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Printer" /> class.
+        /// </summary>
+        /// <param name="printerName">Printer name, shared name or port of printer install</param>
+        /// <param name="type">Command set of type printer</param>
+        /// <param name="encoding">Custom encoding</param>
+        public Printer(string printerName, PrinterType type, Encoding encoding) : this(printerName, type, 0, 0, 0, encoding) { }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Printer" /> class.
+        /// </summary>
+        /// <param name="printerName">Printer name, shared name or port of printer install</param>
         /// <param name="type">>Command set of type printer</param>
-        public Printer(string printerName, PrinterType type) : this(printerName, type, 0, 0, 0) { }
+        public Printer(string printerName, PrinterType type) : this(printerName, type, 0, 0, 0, null) { }
 
         #endregion
 
@@ -151,9 +172,11 @@ namespace Vip.Printer
             var list = new List<byte>();
             if (_buffer != null) list.AddRange(_buffer);
 
-            var bytes = _printerType == PrinterType.Bematech
-                ? Encoding.GetEncoding(850).GetBytes(value)
-                : Encoding.GetEncoding("IBM860").GetBytes(value);
+            var bytes = _encoding != null
+                ? _encoding.GetBytes(value)
+                : _printerType == PrinterType.Bematech
+                    ? Encoding.GetEncoding(850).GetBytes(value)
+                    : Encoding.GetEncoding("IBM860").GetBytes(value);
 
             list.AddRange(bytes);
             _buffer = list.ToArray();

--- a/src/Vip.Printer/Vip.Printer.csproj
+++ b/src/Vip.Printer/Vip.Printer.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
-		<Description>Biblioteca para impressões em mini-impressoras utilizando comandos Esc/Bema e Esc/Pos</Description>
+		<Description>Biblioteca para realizar impressões (impressora não fiscal) utilizando comandos Esc/Bema, Esc/Daruma e Esc/Pos</Description>
 		<Company>VIP Soluções</Company>
 		<Copyright>VIP Soluções - Copyright ©  2019</Copyright>
 		<Authors>Leandro Ferreira</Authors>
-		<Version>1.0.18</Version>
+		<Version>1.0.19</Version>
 		<Tags>vip printer</Tags>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Para impressoras com encodings diferente do padrão da biblioteca foi implementado a opção de ser informado o encoding no construtor do objeto. Caso não informado, será assumido o encoding padrão.

Segue exemplo abaixo:

```csharp
var printer = new Printer("NomeImpressora", PrinterType.Daruma, MeuEncoding);
```